### PR TITLE
Updated version to fix NuGet package metadata

### DIFF
--- a/DIV2.Format.Exporter/DIV2.Format.Exporter.csproj
+++ b/DIV2.Format.Exporter/DIV2.Format.Exporter.csproj
@@ -11,7 +11,7 @@
     <RepositoryType>GitHub</RepositoryType>
     <PackageTags>DIV DIV2 DIVGamesStudio DIVGamesStudio2 Games Graphics Tool Retro Windows Linux Mac</PackageTags>
     <Platforms>x64</Platforms>
-    <Version>1.0.1</Version>
+    <Version>1.0.1.1</Version>
     <NeutralLanguage>en</NeutralLanguage>
     <PackageReleaseNotes>- Compiled as x64 instead of AnyCPU.
 - Updated ImageSharp to version 1.0.3.
@@ -21,6 +21,8 @@
     <PackageIcon>DIV2.png</PackageIcon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <AssemblyVersion>1.0.1.1</AssemblyVersion>
+    <FileVersion>1.0.1.1</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">


### PR DESCRIPTION
Updated version to 1.0.1.1 to force GitHub pipeline to publish the NuGet package with the fixed metadata.